### PR TITLE
Option to change bibliography font size

### DIFF
--- a/inst/rmarkdown/templates/posterdown_pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/posterdown_pdf/resources/template.tex
@@ -96,7 +96,7 @@
 
 %biblatex options
 \RequirePackage[sorting=none,backend=biber]{biblatex}
-\renewcommand*{\bibfont}{\tiny}
+\renewcommand*{\bibfont}{\$bibliography_font_size$}
 \bibliography{$bibliography$}
 \defbibheading{bibliography}[\bibname]{%
 \section*{#1}%

--- a/inst/rmarkdown/templates/posterdown_pdf/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/posterdown_pdf/skeleton/skeleton.Rmd
@@ -35,6 +35,7 @@ column_margins: "10mm" # Margin spacing for columns
 
 #----OTHER----#
 bibliography: MyLibrary # name of the .bib file used for referencing
+bibliography_font_size: "tiny"
 output: posterdown::posterdown_pdf
 ---
 
@@ -163,6 +164,6 @@ There is still **A LOT** of work to do on this package which include (but are no
 - Include References section only if initiated by the user like in RMarkdown.
 
 <!--- Here you can set the size of the citation text as well as remove the "References" section if you choose not to have one for some reason :) -->
-\small\printbibliography
+\printbibliography
 
 

--- a/inst/rmarkdown/templates/posterdown_pdf/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/posterdown_pdf/skeleton/skeleton.Rmd
@@ -35,7 +35,7 @@ column_margins: "10mm" # Margin spacing for columns
 
 #----OTHER----#
 bibliography: MyLibrary # name of the .bib file used for referencing
-bibliography_font_size: "tiny"
+bibliography_font_size: "tiny" # size of the bibliography in latex options (tiny, scriptsize, footnotesize, small, normalsize, etc.)
 output: posterdown::posterdown_pdf
 ---
 


### PR DESCRIPTION
Hi Brent, 
I found a bug when trying to change the font size of the bibliography in that \tiny was hard coded in the template .tex file. I've defined it as a variable now in the .Rmd header so it's easier for users to change the size if they need and removed the \small before printing in the example .Rmd.

Hopefully that helps (first PR)
Thanks!