### PR TITLE
More font size choices and line spacing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,12 @@ YAML header options have been created to provide more freedom in design (i.e. co
 | `title` | Poster title, acts as you would expect from RMarkdown. You can add line breaks in your title with \\break. |
 | `author` | List of authors which (as of now) only has true support for a single author, however I have provided a hacky way to have many authors until I can find the time to figure out how to implement something like the [rticles](https://github.com/rstudio/rticles/blob/master/inst/rmarkdown/templates/mdpi_article/skeleton/skeleton.Rmd) packages does|
 | `affiliation` | Author affiliations, which just as the `author` section is currently a hacky version of what I would ultimately like to produce. |
-| `font_size` | Represents the value for `\normaltextsize` in latex. All other font sizes are adjusted from this baseline. For example, the title in the skeleton document is given the Latex command `\Huge`, meaning that the title text will be "huge" relative to the `font_size` chosen. See [Here](https://www.overleaf.com/learn/latex/Font_sizes,_families,_and_styles) for a useful resource for a better understanding of the Latex text sizing options.|
+| `title_textsize`| Title font size. Sizes can be one of: "tiny", "scriptsize", "footnotesize", "small", "normalsize", "large", "Large", "LARGE", "huge" or "Huge", see `font_size` below for more information.
+| `author_textsize`| Author list font size
+| `affiliation_textsize`| Affiliations list font size
+| `body_textsize`| Font size of the poster's main body
+| `bibliography_textsize`| Bibliography font size
+| `font_size` | Represents the point value for `\normaltextsize` in latex. All other font sizes are adjusted from this baseline. For example, if the title in the skeleton document is given the Latex command `\Huge`, meaning that the title text will be "huge" relative to the `font_size` chosen. See [Here](https://www.overleaf.com/learn/latex/Font_sizes,_families,_and_styles) for a useful resource for a better understanding of the Latex text sizing options.|
 | `font_family` | Selects the font family to be used on the poster. In the future I will try to implement multiple font families for various components of the poster (such as different fonts for the title versus the main body text).  For now, only standard Latex fonts are available, see [here](https://www.overleaf.com/learn/latex/Font_typefaces) for a list of possible options.|
 | `title_bgcol` | The background colour for the title section of the poster (currently using hex values to define this colour) |
 | `poster_bgcol`| Background colour of the poster's main body section. |
@@ -98,6 +103,7 @@ YAML header options have been created to provide more freedom in design (i.e. co
 | `poster_width` | Width of the final poster output. Units can be: "in", "mm", "cm" |
 | `column_numbers` | Number of columns you wish for the poster to have in the main section of the poster. |
 | `bibliography` | Name of the `.bib`. file which you are using to source material. As of right now only `biblatex` is working but I intend to add support of `natbib` which is my preference.
+| `bibliography_spacing` | Sets the mutiplier for line spacing between bibliography entries, default value is `0.8`. Useful if you need to squeeze more space from somewhere.
 | `output` | For generating `posterdown_pdf`, in the future other poster designs or templates may be made for this package and thus this option in the YAML will be more flexible. For now this is the only option. |
 
 ### Markdown Customization

--- a/inst/rmarkdown/templates/posterdown_pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/posterdown_pdf/resources/template.tex
@@ -99,6 +99,7 @@
 \renewcommand*{\bibfont}{\$bibliography_font_size$}
 \bibliography{$bibliography$}
 \defbibheading{bibliography}[\bibname]{%
+\setlength\bibitemsep{$bibliography_spacing$\itemsep}
 \section*{#1}%
 \markboth{#1}{#1}}
 \AtBeginDocument{%

--- a/inst/rmarkdown/templates/posterdown_pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/posterdown_pdf/resources/template.tex
@@ -7,7 +7,7 @@
 %% %%		Brent Thorne
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\documentclass[article,$font_size$,extrafontsizes]{memoir}
+\documentclass[article,30pt,extrafontsizes]{memoir}
 
 %utf-8 seems to be important
 \RequirePackage[utf8]{inputenc}
@@ -184,9 +184,9 @@ $endif$
   \centering
   \color{titletextcol}
 \vspace{0.5in}
-  \Huge{$title$}  \\[0.3in]
-  \color{authortextcol} \Large{$author$} \\[0.2in]
-  \color{affiliationtextcol} \large{$affiliation$}
+  \$title_font_size${$title$}  \\[0.3in]
+  \color{authortextcol} \$author_size${$author$} \\[0.2in]
+  \color{affiliationtextcol} \$affiliation_size${$affiliation$}
   \vspace{0.2in}
 
 % end title section -------------------
@@ -195,7 +195,7 @@ $endif$
 
 % Brgin body of poster
 \begin{adjmulticols*}{$column_numbers$}{10mm}{10mm}
-\normalsize{
+\$body_font_size${
 \color{bodytextcol}
 $body$
 }

--- a/inst/rmarkdown/templates/posterdown_pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/posterdown_pdf/resources/template.tex
@@ -7,7 +7,7 @@
 %% %%		Brent Thorne
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\documentclass[article,30pt,extrafontsizes]{memoir}
+\documentclass[article,$font_size$,extrafontsizes]{memoir}
 
 %utf-8 seems to be important
 \RequirePackage[utf8]{inputenc}

--- a/inst/rmarkdown/templates/posterdown_pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/posterdown_pdf/resources/template.tex
@@ -5,6 +5,7 @@
 %% %%
 %% %%	Initial class provided by:
 %% %%		Brent Thorne
+%% %% Contributors: Shea Connell (SC)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \documentclass[article,$font_size$,extrafontsizes]{memoir}
@@ -96,10 +97,10 @@
 
 %biblatex options
 \RequirePackage[sorting=none,backend=biber]{biblatex}
-\renewcommand*{\bibfont}{\$bibliography_font_size$}
+\renewcommand*{\bibfont}{\$bibliography_textsize$} %% SC
 \bibliography{$bibliography$}
 \defbibheading{bibliography}[\bibname]{%
-\setlength\bibitemsep{$bibliography_spacing$\itemsep}
+\setlength\bibitemsep{$bibliography_spacing$\itemsep} %% SC
 \section*{#1}%
 \markboth{#1}{#1}}
 \AtBeginDocument{%
@@ -185,9 +186,9 @@ $endif$
   \centering
   \color{titletextcol}
 \vspace{0.5in}
-  \$title_font_size${$title$}  \\[0.3in]
-  \color{authortextcol} \$author_size${$author$} \\[0.2in]
-  \color{affiliationtextcol} \$affiliation_size${$affiliation$}
+  \$title_textsize${$title$}  \\[0.3in]  %% SC
+  \color{authortextcol} \$author_textsize${$author$} \\[0.2in] %% SC
+  \color{affiliationtextcol} \$affiliation_textsize${$affiliation$} %% SC
   \vspace{0.2in}
 
 % end title section -------------------
@@ -196,7 +197,7 @@ $endif$
 
 % Brgin body of poster
 \begin{adjmulticols*}{$column_numbers$}{10mm}{10mm}
-\$body_font_size${
+\$body_textsize${  %% SC
 \color{bodytextcol}
 $body$
 }

--- a/inst/rmarkdown/templates/posterdown_pdf/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/posterdown_pdf/skeleton/skeleton.Rmd
@@ -8,12 +8,12 @@ affiliation: "^1^Department of Poster Layouts, University of Markdown; ^2^Deparm
 font_family: "palatino" # choose from typical latex fonts (example: "palatino")
 font_size: "30pt" #sets '\normalsize' (sizes of the title and sections headings will adjust based on it, not recommended as memoir has limited options)
 
-# Sizes are standard Latex options (tiny, scriptsize, footnotesize, small, normalsize, large, Large, LARGE, huge and Huge)
-title_font_size: "Huge"         # Poster title fontsize
-author_size: "Large"            # Author list font size
-affiliation_size: "large"       # Affiliation font size
-body_font_size: "normalsize"    # Size of the main poster body text
-bibliography_font_size: "tiny"  # size of the bibliography text size (handy for one too many references!)
+# Sizes are standard LaTeX options (tiny, scriptsize, footnotesize, small, normalsize, large, Large, LARGE, huge and Huge)
+title_textsize: "Huge"         # Poster title fontsize
+author_textsize: "Large"       # Author list font size
+affiliation_textsize: "large"  # Affiliation font size
+body_textsize: "normalsize"    # Size of the main poster body text
+bibliography_textsize: "tiny"  # size of the bibliography text size (handy for one too many references!)
 
 #----COLOURS----#
 

--- a/inst/rmarkdown/templates/posterdown_pdf/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/posterdown_pdf/skeleton/skeleton.Rmd
@@ -9,11 +9,11 @@ font_family: "palatino" # choose from typical latex fonts (example: "palatino")
 font_size: "30pt" #sets '\normalsize' (sizes of the title and sections headings will adjust based on it, not recommended as memoir has limited options)
 
 # Sizes are standard Latex options (tiny, scriptsize, footnotesize, small, normalsize, large, Large, LARGE, huge and Huge)
-title_font_size: "Huge" # size of the poster title
-author_size: "Large"
-bibliography_font_size: "tiny" # size of the bibliography in latex options ( etc.)
-affiliation_size: "large"
-body_font_size: "normalsize" # size of body text
+title_font_size: "Huge"         # Poster title fontsize
+author_size: "Large"            # Author list font size
+affiliation_size: "large"       # Affiliation font size
+body_font_size: "normalsize"    # Size of the main poster body text
+bibliography_font_size: "tiny"  # size of the bibliography text size (handy for one too many references!)
 
 #----COLOURS----#
 
@@ -42,7 +42,7 @@ column_margins: "10mm" # Margin spacing for columns
 
 #----OTHER----#
 bibliography: MyLibrary # name of the .bib file used for referencing
-
+bibliography_spacing: 0.8 # sets the multiplier for line spacing of bibliography spacing (between 0 and 1)
 output: posterdown::posterdown_pdf
 ---
 

--- a/inst/rmarkdown/templates/posterdown_pdf/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/posterdown_pdf/skeleton/skeleton.Rmd
@@ -4,9 +4,16 @@ title: '\fontfamily{phv}\selectfont Using posterdown to generate reproducible co
 author: "Author One^1^ Author Two^2^"
 affiliation: "^1^Department of Poster Layouts, University of Markdown; ^2^Deparment of Another Institution, Institution University"
 
-#----FONT STYLE----#
-font_size: "30pt" #sets '\normalsize' (sizes of the title and sections headings will adjust based on it)
+#----FONT STYLE & SIZE----#
 font_family: "palatino" # choose from typical latex fonts (example: "palatino")
+font_size: "30pt" #sets '\normalsize' (sizes of the title and sections headings will adjust based on it, not recommended as memoir has limited options)
+
+# Sizes are standard Latex options (tiny, scriptsize, footnotesize, small, normalsize, large, Large, LARGE, huge and Huge)
+title_font_size: "Huge" # size of the poster title
+author_size: "Large"
+bibliography_font_size: "tiny" # size of the bibliography in latex options ( etc.)
+affiliation_size: "large"
+body_font_size: "normalsize" # size of body text
 
 #----COLOURS----#
 
@@ -35,7 +42,7 @@ column_margins: "10mm" # Margin spacing for columns
 
 #----OTHER----#
 bibliography: MyLibrary # name of the .bib file used for referencing
-bibliography_font_size: "tiny" # size of the bibliography in latex options (tiny, scriptsize, footnotesize, small, normalsize, etc.)
+
 output: posterdown::posterdown_pdf
 ---
 

--- a/inst/rmarkdown/templates/posterdown_pdf/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/posterdown_pdf/skeleton/skeleton.Rmd
@@ -35,7 +35,7 @@ column_margins: "10mm" # Margin spacing for columns
 
 #----OTHER----#
 bibliography: MyLibrary # name of the .bib file used for referencing
-bibliography_font_size: "tiny"
+bibliography_font_size: "tiny" # size of the bibliography in latex options (tiny, scriptsize, footnotesize, small, normalsize, etc.)
 output: posterdown::posterdown_pdf
 ---
 


### PR DESCRIPTION
I've added a line spacing option/modifier for when you've got too many references you need to squish down. Also added a range of font size choices, all as the standard latex font size choices. I think being able to specify pt size for sections might be useful. 

I've left the default memoir class option in, but the options are very limited and solutions seem very fragile. The next lowest option from 30pt is 25pt for example (too small in my opinion).

Thanks for making this package by the way, forced me to learn latex finally!