### PR TITLE
Adding a header-includes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ YAML header options have been created to provide more freedom in design (i.e. co
 | `url_col` | LaTeX | Colour of URL links specifically. |
 | `link_col` | HTML, LaTeX | Colour of in-document links (example would be referencing a Figure or a Table). |
 | `footnote_textcol` | LaTeX | Colour of the footnote text. |
+| `header-includes` | LaTeX | (Optional) Content to include in the header, provided as a one line command or a YAML list with one command per line. For example, to use a sans-serif font as the default font: `header-includes: \renewcommand{\familydefault}{\sfdefault}`.|
 | `output` | HTML, LaTeX | For generating `posterdown_html` or `posterdown_latex`, in the future other poster designs or templates may be made for this package and thus this option in the YAML will be more flexible. `posterdown_pdf` will be kept for legacy use but will not be updated, new projects which would have used it should now use `posterdown_latex`.|
 
 ## Markdown Customization

--- a/inst/rmarkdown/templates/posterdown_latex/resources/template.tex
+++ b/inst/rmarkdown/templates/posterdown_latex/resources/template.tex
@@ -212,6 +212,11 @@ $endif$
 \renewcommand\footnoterule{}
 \renewcommand{\thempfootnote}{\footnotesize\color{footnotetextcol}{\arabic{mpfootnote}}}
 
+%include arbitrary input from header-includes field
+$for(header-includes)$
+$header-includes$
+$endfor$
+
 %-------------- Begin Document -------------------%
 \begin{document}
 


### PR DESCRIPTION
Hey @brentthorne - super cool package! I'm using this to make a poster, and wanted to use a sans-serif font for the whole poster. This PR adds an optional `header-includes` parameter to posterdown that enables this, along with any other tweaks that users might want to include in the header. This could make posterdown more flexible for end users.

This PR includes a change to the `.tex` template that includes commands from `header-includes`, as well as a description and example usage of the `header-includes` option in the README.

This feature may be relevant for some of the questions brought up in https://github.com/brentthorne/posterdown/issues/45

### Testing this feature

1. Make a new poster:

```r
rmarkdown::draft("MyPoster.Rmd", template = "posterdown_latex", package = "posterdown")
```

2. Edit the YAML frontmatter of `MyPoster.Rmd` to specify a custom font_family and include some arbitrary text in the header. For example, to use Helvetica as the default font:

<pre>
---
# PLEASE SEE THE README for in depth description github.com/brentthorne/posterdown
...
poster_width: "45in" # width in inches of poster
<b>font_family: "helvet" </b># choose from typical latex fonts (example: "palatino")
font_size: "30pt" #please see github.com/brentthorne/posterdown for compatible options.
...
footnote_textcol: "ffffff" # Colour of footnote text if used
<b>header-includes: \renewcommand{\familydefault}{\sfdefault} </b>
output: posterdown::posterdown_latex
---
</pre>

3. Render the Rmd file, and notice Helvetica is used as the default font. 