### PR TITLE
Add custom css support to posterdown_betterport and posterdown_betterland

### DIFF
--- a/inst/rmarkdown/templates/posterdown_betterland/resources/template.html
+++ b/inst/rmarkdown/templates/posterdown_betterland/resources/template.html
@@ -298,6 +298,9 @@ span > #tab:mytable {
   width: 3%;
 }
 </style>
+$if(custom_css)$
+<link rel="stylesheet" href=$custom_css$>
+$else$$endif$
 </head>
 <body>
 

--- a/inst/rmarkdown/templates/posterdown_betterport/resources/template.html
+++ b/inst/rmarkdown/templates/posterdown_betterport/resources/template.html
@@ -367,6 +367,9 @@ span > #tab:mytable {
   color: #ffffff;
 }
 </style>
+$if(custom_css)$
+<link rel="stylesheet" href=$custom_css$>
+$else$$endif$
 </head>
 <body>
 


### PR DESCRIPTION
Support for `posterdown_html` was added in ba245c9, but not to `posterdown_betterport` and `posterdown_betterland`. This allows to use custom css with these templates. 