### PR TITLE
Add the mozilla column gap definition for the betterland template.

### DIFF
--- a/inst/rmarkdown/templates/posterdown_betterland/resources/template.html
+++ b/inst/rmarkdown/templates/posterdown_betterland/resources/template.html
@@ -161,8 +161,12 @@ column-rule-style: solid;
 column-rule-color: black;
 $if(main_width)$
 -webkit-column-gap: calc($main_width$ * 100%);
+-moz-column-gap: calc($main_width$ * 100%);
+column-gap: calc($main_width$ * 100%);
 $else$
 -webkit-column-gap: 50%;
+-moz-column-gap: 50%;
+column-gap: 50%;
 $endif$
 background-color: $if(body_bgcol)$$body_bgcol$$else$#ffffff$endif$;
 font-family: $if(font_family)$$font_family$$else$Rasa$endif$;


### PR DESCRIPTION
Hi Brent,
cool package!

I tried out the betterland template, but the outer columns weren't formatted correctly. 
I found out, that the column-gap option was only set for chrome. 

I could make it work with the following commit.